### PR TITLE
Refactor test resource files into subdirectory

### DIFF
--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -52,12 +52,12 @@ TEST_F(NginxParseConfigTest, Comment) {
 
 // Tests the provided example file from the fork
 TEST_F(NginxParseConfigTest, ProvidedExampleFile) {
-	EXPECT_TRUE(parse_file("example_config"));
+	EXPECT_TRUE(parse_file("resources/example_config"));
 }
 
 // Tests the current nginx example config as of 2017-01-18
 // See https://www.nginx.com/resources/wiki/start/topics/examples/full/
 // 
 TEST_F(NginxParseConfigTest, NginxOfficialExampleFile) {
-	EXPECT_TRUE(parse_file("nginx_example.conf"));
+	EXPECT_TRUE(parse_file("resources/nginx_example.conf"));
 }

--- a/resources/example_config
+++ b/resources/example_config
@@ -1,0 +1,7 @@
+foo "bar";
+
+server {
+  listen   80;
+  server_name foo.com;
+  root /home/ubuntu/sites/foo/;
+}

--- a/resources/nginx_example.conf
+++ b/resources/nginx_example.conf
@@ -1,0 +1,70 @@
+user       www www;  ## Default: nobody
+worker_processes  5;  ## Default: 1
+error_log  logs/error.log;
+pid        logs/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+  include    conf/mime.types;
+  include    /etc/nginx/proxy.conf;
+  include    /etc/nginx/fastcgi.conf;
+  index    index.html index.htm index.php;
+
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   logs/access.log  main;
+  sendfile     on;
+  tcp_nopush   on;
+  server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+
+  server { # php/fastcgi
+    listen       80;
+    server_name  domain1.com www.domain1.com;
+    access_log   logs/domain1.access.log  main;
+    root         html;
+
+    location ~ \.php$ {
+      fastcgi_pass   127.0.0.1:1025;
+    }
+  }
+
+  server { # simple reverse-proxy
+    listen       80;
+    server_name  domain2.com www.domain2.com;
+    access_log   logs/domain2.access.log  main;
+
+    # serve static files
+    location ~ ^/(images|javascript|js|css|flash|media|static)/  {
+      root    /var/www/virtual/big.server.com/htdocs;
+      expires 30d;
+    }
+
+    # pass requests for dynamic content to rails/turbogears/zope, et al
+    location / {
+      proxy_pass      http://127.0.0.1:8080;
+    }
+  }
+
+  upstream big_server_com {
+    server 127.0.0.3:8000 weight=5;
+    server 127.0.0.3:8001 weight=5;
+    server 192.168.0.1:8000;
+    server 192.168.0.1:8001;
+  }
+
+  server { # simple load balancing
+    listen          80;
+    server_name     big.server.com;
+    access_log      logs/big.server.access.log main;
+
+    location / {
+      proxy_pass      http://big_server_com;
+    }
+  }
+}


### PR DESCRIPTION
Refactored unit test resources into a subdirectory to provide better interoperability with the Code Monkies (CM) repository.

In the CM repo, we produce a test binary under /bin based on some unit tests pulled from /lib/nginx-configparser (this repo). To avoid having example_config and nginx_sample.conf on the same level as executables, I refactored them into a subdirectory in both the CM repo and this repo.